### PR TITLE
Refine UI with minimalist three‑color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,28 +15,28 @@
     <!-- Visualization & Content Choices: Report Info (Daily schedule) -> Goal (Track and customize tasks/actions) -> Viz Method (Interactive horizontal timeline with clickable days, dynamic detail view with checkboxes or editable inputs) -> Interaction (Click to show details, checkboxes to mark completion, button to toggle edit mode, input fields for editing, add/delete buttons for items) -> Justification (Provides a clear overview and empowers user to manage tasks directly and adapt the plan). All interactions are handled with vanilla JS on a structured data array, ensuring no complex libraries are needed and confirming NO SVG/Mermaid. -->
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
 </head>
-<body class="antialiased text-gray-800 gradient-bg">
+<body class="antialiased text-dark gradient-bg">
 
     <div class="container mx-auto p-4 md:p-8 max-w-5xl">
         <header class="text-center mb-12">
             <h1 class="logo text-4xl md:text-5xl font-extrabold">WoningPlanner</h1>
-            <p class="text-slate-700 mt-3 text-lg">Plan en beheer je renovatieproject</p>
+            <p class="text-dark mt-3 text-lg">Plan en beheer je renovatieproject</p>
         </header>
 
         <main>
             <div class="glass-card p-4 md:p-6 mb-8">
                 <div class="mb-4">
-                     <h2 class="text-lg font-semibold text-slate-700 mb-2">Projectvoortgang</h2>
-                     <div class="w-full bg-stone-200 rounded-full h-4">
+                     <h2 class="text-lg font-semibold text-dark mb-2">Projectvoortgang</h2>
+                     <div class="w-full progress-track rounded-full h-4">
                         <div id="progress-bar" class="h-4 rounded-full transition-all duration-500" style="width: 0%;"></div>
                      </div>
                 </div>
-                 <div id="progress-text" class="text-sm text-center text-slate-600"></div>
+                 <div id="progress-text" class="text-sm text-center text-muted"></div>
             </div>
 
             <div class="glass-card p-4 md:p-6 mb-8">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-                    <h2 class="text-lg font-semibold text-slate-700">Tijdlijn</h2>
+                    <h2 class="text-lg font-semibold text-dark">Tijdlijn</h2>
                     <div class="flex flex-wrap gap-2 mt-4 sm:mt-0">
                         <button id="edit-planning-btn" class="button-primary px-4 py-2">Bewerk Planning</button>
                         <button id="reset-btn" class="button-secondary px-4 py-2">Reset</button>
@@ -52,7 +52,7 @@
             </div>
         </main>
 
-        <footer class="text-center mt-12 text-sm text-slate-500">
+        <footer class="text-center mt-12 text-sm text-muted">
             <p>Deze planning is een indicatie. Werkelijke data kunnen afwijken.</p>
         </footer>
     </div>

--- a/script.js
+++ b/script.js
@@ -298,7 +298,7 @@ document.addEventListener('DOMContentLoaded', () => {
     workDays.forEach((day) => {
       const dayCard = document.createElement('div');
       dayCard.className =
-        'day-card glass-card flex-shrink-0 w-32 h-32 p-3 border-2 border-stone-200 rounded-lg cursor-pointer hover:border-blue-400 hover:shadow-lg';
+        'day-card glass-card flex-shrink-0 w-32 h-32 p-3 rounded-lg cursor-pointer';
       dayCard.dataset.day = day.day;
 
       const date = new Date(day.date + 'T00:00:00');
@@ -307,11 +307,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       dayCard.innerHTML = `
         <div class="flex justify-between items-center text-sm mb-1">
-          <span class="font-bold text-slate-700">Dag ${day.day}</span>
+          <span class="font-bold text-dark">Dag ${day.day}</span>
         </div>
-        <div class="text-xs text-slate-500">${dayOfWeek}</div>
-        <div class="text-sm font-semibold text-slate-600">${dayOfMonth}</div>
-        <div class="text-xs text-slate-500 mt-2 truncate">${day.title}</div>
+        <div class="text-xs text-muted">${dayOfWeek}</div>
+        <div class="text-sm font-semibold text-dark">${dayOfMonth}</div>
+        <div class="text-xs text-muted mt-2 truncate">${day.title}</div>
       `;
 
       dayCard.addEventListener('click', () => {
@@ -329,8 +329,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!dayData) {
       detailsContainer.innerHTML = `
         <div class="glass-card p-6 text-center detail-card-enter">
-          <h3 class="text-xl font-bold text-slate-800">${t('welcomeTitle')}</h3>
-          <p class="text-slate-600 mt-2">${t('welcomeText')}</p>
+          <h3 class="text-xl font-bold text-dark">${t('welcomeTitle')}</h3>
+          <p class="text-muted mt-2">${t('welcomeText')}</p>
         </div>`;
       return;
     }
@@ -342,23 +342,23 @@ document.addEventListener('DOMContentLoaded', () => {
         .map(
           (task, index) => `
         <li class="flex items-center mb-2">
-          <input type="text" value="${task.text}" data-type="tasks" data-id="${task.id}" class="flex-grow border rounded-md px-2 py-1 mr-2 text-slate-700">
-          <button onclick="deleteItem(${dayData.day}, 'tasks', ${index})" aria-label="delete" class="text-red-500 hover:text-red-700 text-xl leading-none">🗑️</button>
+          <input type="text" value="${task.text}" data-type="tasks" data-id="${task.id}" class="flex-grow border rounded-md px-2 py-1 mr-2 text-dark">
+          <button onclick="deleteItem(${dayData.day}, 'tasks', ${index})" aria-label="delete" class="text-accent hover:opacity-80 text-xl leading-none">🗑️</button>
         </li>`
         )
         .join('');
-      tasksHtml += `<button onclick="addItem(${dayData.day}, 'tasks')" class="mt-4 px-3 py-1 bg-green-600 text-white rounded-md hover:bg-green-700 transition">${t('newTask')}</button>`;
+      tasksHtml += `<button onclick="addItem(${dayData.day}, 'tasks')" class="mt-4 px-3 py-1 bg-primary rounded-md hover:opacity-90 transition">${t('newTask')}</button>`;
 
       residentActionsHtml = dayData.residentActions
         .map(
           (action, index) => `
         <li class="flex items-center mb-2">
-          <input type="text" value="${action.text}" data-type="residentActions" data-id="${action.id}" class="flex-grow border rounded-md px-2 py-1 mr-2 text-slate-700">
-          <button onclick="deleteItem(${dayData.day}, 'residentActions', ${index})" aria-label="delete" class="text-red-500 hover:text-red-700 text-xl leading-none">🗑️</button>
+          <input type="text" value="${action.text}" data-type="residentActions" data-id="${action.id}" class="flex-grow border rounded-md px-2 py-1 mr-2 text-dark">
+          <button onclick="deleteItem(${dayData.day}, 'residentActions', ${index})" aria-label="delete" class="text-accent hover:opacity-80 text-xl leading-none">🗑️</button>
         </li>`
         )
         .join('');
-      residentActionsHtml += `<button onclick="addItem(${dayData.day}, 'residentActions')" class="mt-4 px-3 py-1 bg-green-600 text-white rounded-md hover:bg-green-700 transition">${t('newAction')}</button>`;
+      residentActionsHtml += `<button onclick="addItem(${dayData.day}, 'residentActions')" class="mt-4 px-3 py-1 bg-primary rounded-md hover:opacity-90 transition">${t('newAction')}</button>`;
     } else {
       tasksHtml = dayData.tasks
         .map((task) => {
@@ -388,14 +388,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     detailsContainer.innerHTML = `
       <div class="glass-card p-6 md:p-8 detail-card-enter">
-        <h3 class="text-xl font-bold text-slate-800 mb-4">Details voor Dag ${dayData.day} (${new Date(dayData.date + 'T00:00:00').toLocaleDateString('nl-NL', { weekday: 'long', day: 'numeric', month: 'long' })})</h3>
+        <h3 class="text-xl font-bold text-dark mb-4">Details voor Dag ${dayData.day} (${new Date(dayData.date + 'T00:00:00').toLocaleDateString('nl-NL', { weekday: 'long', day: 'numeric', month: 'long' })})</h3>
         <div class="grid md:grid-cols-2 gap-8">
           <div>
-            <h4 class="font-semibold text-slate-700 mb-2 border-b pb-2">Werkzaamheden</h4>
+            <h4 class="font-semibold text-dark mb-2 border-b pb-2">Werkzaamheden</h4>
             <ul class="list-none p-0 m-0" id="tasks-list">${tasksHtml}</ul>
           </div>
           <div>
-            <h4 class="font-semibold text-slate-700 mb-2 border-b pb-2">Wat u moet doen</h4>
+            <h4 class="font-semibold text-dark mb-2 border-b pb-2">Wat u moet doen</h4>
             <ul class="list-none p-0 m-0" id="resident-actions-list">${residentActionsHtml}</ul>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,11 @@
 :root {
-    --brand-bg-start: #6EE7B7;
-    --brand-bg-mid: #3B82F6;
-    --brand-bg-end: #9333EA;
-    --accent-start: #F472B6;
-    --accent-end: #8B5CF6;
-    --text-color: #1C1C1E;
+    --color-primary: #3B82F6;
+    --color-accent: #F59E0B;
+    --color-dark: #1F2937;
+    --color-dark-rgb: 31, 41, 55;
+    --color-primary-rgb: 59, 130, 246;
+    --color-accent-rgb: 245, 158, 11;
+    --text-color: var(--color-dark);
 }
 
 body {
@@ -15,7 +16,7 @@ body {
 
 /* Animated gradient background */
 .gradient-bg {
-    background: linear-gradient(115deg, var(--brand-bg-start), var(--brand-bg-mid), var(--brand-bg-end));
+    background: linear-gradient(115deg, var(--color-primary), var(--color-dark), var(--color-accent));
     background-size: 400% 400%;
     animation: gradientShift 15s ease infinite;
     min-height: 100vh;
@@ -30,14 +31,14 @@ body {
     height: 8px;
 }
 .timeline-container::-webkit-scrollbar-track {
-    background: #E7E5E4; /* stone-200 */
+    background: rgba(var(--color-dark-rgb), 0.1);
 }
 .timeline-container::-webkit-scrollbar-thumb {
-    background: #C7C7CC; /* iOS scrollbar */
+    background: rgba(var(--color-dark-rgb), 0.3);
     border-radius: 4px;
 }
 .timeline-container::-webkit-scrollbar-thumb:hover {
-    background: #A1A1AA; /* darker on hover */
+    background: rgba(var(--color-dark-rgb), 0.5);
 }
 
 /* glass effect card */
@@ -53,14 +54,16 @@ body {
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(6px);
     animation: fadeInUp 0.5s ease;
+    border: 2px solid rgba(var(--color-dark-rgb), 0.2);
 }
 .day-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+    border-color: var(--color-primary);
 }
 .day-card.active {
-    border-color: var(--accent-end);
-    box-shadow: 0 4px 10px rgba(124, 58, 237, 0.4);
+    border-color: var(--color-primary);
+    box-shadow: 0 4px 10px rgba(var(--color-primary-rgb), 0.4);
 }
 .detail-card-enter {
     animation: fadeInUp 0.6s ease;
@@ -83,17 +86,17 @@ body {
 }
 .task-item.completed span {
     text-decoration: line-through;
-    color: #6B7280; /* gray-500 */
+    color: rgba(var(--color-dark-rgb), 0.5);
 }
 
 #progress-bar {
-    background: linear-gradient(90deg, var(--accent-start), var(--accent-end));
-    box-shadow: 0 4px 6px rgba(139, 92, 246, 0.3);
+    background: linear-gradient(90deg, var(--color-primary), var(--color-accent));
+    box-shadow: 0 4px 6px rgba(var(--color-primary-rgb), 0.3);
     transition: width 0.4s ease;
 }
 
 .button-primary {
-    background: linear-gradient(90deg, var(--accent-start), var(--accent-end));
+    background: linear-gradient(90deg, var(--color-primary), var(--color-accent));
     color: #fff;
     border-radius: 0.5rem;
     transition: opacity 0.15s ease;
@@ -103,7 +106,7 @@ body {
 }
 .button-secondary {
     background: rgba(255, 255, 255, 0.2);
-    color: #1C1C1E;
+    color: var(--color-dark);
     border-radius: 0.5rem;
     transition: background-color 0.15s ease;
 }
@@ -112,6 +115,30 @@ body {
 }
 
 .logo {
-    color: var(--brand-bg-mid);
+    color: var(--color-primary);
     letter-spacing: -0.5px;
+}
+
+.text-dark {
+    color: var(--color-dark);
+}
+.text-muted {
+    color: rgba(var(--color-dark-rgb), 0.7);
+}
+.text-accent {
+    color: var(--color-accent);
+}
+.bg-primary {
+    background-color: var(--color-primary);
+    color: #fff;
+}
+.bg-primary:hover {
+    opacity: 0.9;
+}
+.text-accent:hover {
+    opacity: 0.8;
+}
+
+.progress-track {
+    background: rgba(var(--color-dark-rgb), 0.1);
 }


### PR DESCRIPTION
## Summary
- simplify color scheme to three main colors
- update layout styles and add helper classes
- rework markup to use new classes
- clean up JS templates for new style classes

## Testing
- `grep -o '#[0-9A-Fa-f]\{6\}' style.css | sort -u`

------
https://chatgpt.com/codex/tasks/task_e_684188aac71883289cbb68bdcb3d8460